### PR TITLE
A spelling mistake in the file.

### DIFF
--- a/lib/havenondemand.rb
+++ b/lib/havenondemand.rb
@@ -1,6 +1,6 @@
 
 
-require 'Unirest'
+require 'unirest'
 require 'json'
 #require 'httpclient'
 


### PR DESCRIPTION
I was using this API at an angelhack hackathon. If you use "Unirest" there it shows an error but if you change it to "unirest" it gets solved. Look at image for more info
[Imade Showing the error and afterwords the patch](http://i.imgur.com/AZt7IMj.png)
